### PR TITLE
Add support for handling non string values in json

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const jnestedReplace = (input, searchValue, newValue, skipKeys=[]) => {
     // for every element of array
     if (isArray(input[key])) {
       for (let i=0; i<input[key].length; i++) {
+
         input[key][i] = jnestedReplace(input, searchValue, newValue, skipKeys);
       }
       continue;
@@ -38,7 +39,7 @@ const jnestedReplace = (input, searchValue, newValue, skipKeys=[]) => {
 
     // If the key needs to be skipped.
     // Do not process and continue to next element
-    if (skipKeys.indexOf(key) === -1) {
+    if (skipKeys.indexOf(key) === -1 && isString(input[key])) {
       input[key] = input[key].replace(searchValue, newValue);
     }
   }
@@ -55,6 +56,12 @@ const isObject = (data) => {
 // checks if data is an array
 const isArray = (data) => {
   return data instanceof Array;
+};
+
+// check id the data is string
+const isString = (data) => {  
+  return typeof data === 'string' 
+    && Object.prototype.toString.call(data) === '[object String]';
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "json-nested-replace",
       "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-nested-replace",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Searches and replace values at every level of nested json ",
   "main": "index.js",
   "scripts": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -101,4 +101,34 @@ describe('replace in nested json', () => {
     expect(replacedValue.repository.url).to.equal(INPUT_JSON.repository.url);
     expect(replacedValue.name).to.be.equal('jnested-replace');
   });
+  it('show skip the values which are not string', () => {
+    const input = {
+      'name': 'json-nested-replace',
+      'author': 'Arshad Kazmi',
+      'number': 1234,
+      'boolean': true,
+      'repository': {
+        'url': 'https://github.com/arshadkazmi42/json-nested-replace',
+        'language': 'js',
+        'numberString': '1234',
+        'booleanString': 'true'
+      }
+    };
+
+    const expected = {
+      'name': 'json-nested-replace',
+      'author': 'Arshad Kazmi',
+      'number': 1234,
+      'boolean': true,
+      'repository': {
+        'url': 'https://github.com/arshadkazmi42/json-nested-replace',
+        'language': 'js',
+        'numberString': '4321',
+        'booleanString': 'true'
+      }
+    };
+
+    const updatedInput = jnestedReplace(input, '1234', '4321');
+    expect(updatedInput).to.be.deep.equals(expected);
+  });
 });


### PR DESCRIPTION
Fixes #24 

## Context

The error was caused, due to the `replace` method being called on all the values without checking the type of the value and when the value was not string it was throwing `replace` method not found on the value.

## Summary

Add handler to check if the value is string, before actually calling `replace` method on the value. 
With this, this library supports replacing of only strings now.

May be next versions, we should add support for replacing `integers` and `boolean` too